### PR TITLE
Bump Composer dependency to Laravel 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The package gives you the opportunity to customize Artisan commands like `artisa
 Any location of the generated classes and with any content.
 
 
-## Installation for Laravel 5.5 / 5.6
+## Installation for Laravel 5.5 - 5.7
 > *For older laravel versions see: [older installation](https://github.com/atehnix/laravel-stubs/tree/v2.0.0#installation)*
 
 You can get library through [composer](https://getcomposer.org/)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "~5.6.0"
+        "laravel/framework": "5.5 - 5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
maybe also `5.5 - 5.7` is working, to increase the compability