### PR TITLE
Update FactoryMakeCommand to follow Laravel's

### DIFF
--- a/src/Console/FactoryMakeCommand.php
+++ b/src/Console/FactoryMakeCommand.php
@@ -11,61 +11,10 @@
 namespace ATehnix\LaravelStubs\Console;
 
 use Illuminate\Database\Console\Factories\FactoryMakeCommand as BaseFactoryMakeCommand;
-use Illuminate\Support\Str;
 
 class FactoryMakeCommand extends BaseFactoryMakeCommand
 {
     use Modulable;
-
-    /**
-     * The Laravel application instance.
-     *
-     * @var \Illuminate\Foundation\Application
-     */
-    protected $laravel;
-
-    /**
-     * Build the class with the given name.
-     *
-     * @param  string $name
-     * @return string
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
-    protected function buildClass($name)
-    {
-        $model = $this->option('model')
-            ? $this->parseModel($this->option('model'))
-            : 'Model';
-
-        $stub = $this->files->get($this->getStub());
-        $stub = $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
-
-        return str_replace(
-            'DummyModel', $model, $stub
-        );
-    }
-
-    /**
-     * Get the fully-qualified model class name.
-     *
-     * @param  string $model
-     * @return string
-     */
-    protected function parseModel($model)
-    {
-        $model = trim(str_replace('/', '\\', $model), '\\');
-
-        $namespace =
-            trim($this->laravel->getNamespace(), '\\')
-            . $this->getModuleNamespace()
-            . config('stubs.namespaces.model') . '\\';
-
-        if (!Str::startsWith($model, $namespace)) {
-            $model = $namespace . $model;
-        }
-
-        return $model;
-    }
 
     /**
      * Get the stub file for the generator.
@@ -77,5 +26,16 @@ class FactoryMakeCommand extends BaseFactoryMakeCommand
         $stub = config('stubs.path') . '/factory.stub';
 
         return file_exists($stub) ? $stub : parent::getStub();
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . $this->getModuleNamespace() . config('stubs.namespaces.model');
     }
 }


### PR DESCRIPTION
They added a new replacement: "NamespacedDummyModel"

It matches 90% of the other commands now too. :)